### PR TITLE
Remove redundant open3d in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,4 @@ scikit-learn
 openai
 pyyaml==5.4.1
 opencv-python
-open3d
 SpeechRecognition


### PR DESCRIPTION
It was tripping up pip:
```
(venv) russt@home-cart13:~/tmp/open-world-tamp$ pip3 install -r requirements.txt
ERROR: Double requirement given: open3d (from -r requirements.txt (line 23)) (already in open3d>=0.13.0 (from -r requirements.txt (line 14)), name='open3d')
```
as the error message says, open3d was already listed explicitly just above.